### PR TITLE
Account for Date and Number mismatches

### DIFF
--- a/lib/entries.js
+++ b/lib/entries.js
@@ -36,6 +36,18 @@ function Entries(entries) {
     return 0;
   }
 
+  function datesEqual(dateOrNumA, dateOrNumB) {
+    if(dateOrNumA instanceof Date) {
+      dateOrNumA = dateOrNumA.getTime();
+    }
+
+    if(dateOrNumB instanceof Date) {
+      dateOrNumB = dateOrNumB.getTime();
+    }
+
+    return dateOrNumA === dateOrNumB;
+  }
+
   function diffUpdates(updates) {
     var sortedUpdates = updates.slice().sort(sortByRelativePath);
     var sortedEntries = entries.slice().sort(sortByRelativePath);
@@ -47,7 +59,11 @@ function Entries(entries) {
         throw new Error('Mismatch in files');
       }
 
-      return _entry.mtime !== entry.mtime || _entry.size !== entry.size || _entry.mode !== entry.mode;
+      var mtimeChanged = !datesEqual(_entry.mtime, entry.mtime); // mtime may be an integer or a Date
+      var sizeChanged = _entry.size !== entry.size;
+      var modeChanged = _entry.mode !== entry.mode;
+
+      return mtimeChanged || sizeChanged || modeChanged;
 
     });
   }

--- a/tests/fs-tree-test.js
+++ b/tests/fs-tree-test.js
@@ -134,7 +134,7 @@ describe('FSTree', function() {
         ]);
       });
 
-      it('should diff by mtime', function() {
+      it('should diff by mtime (Number)', function() {
         var result = entries.update([
           { relativePath: 'a/b.js', mode: '0o666', size: 1, mtime: 10 },
           { relativePath: 'b.js', mode: '0o666', size: 2, mtime: 1 }
@@ -142,6 +142,18 @@ describe('FSTree', function() {
 
         expect(result).to.deep.equal([
           { relativePath: 'a/b.js', mode: '0o666', size: 1, mtime: 10 }
+        ]);
+      });
+
+      it('should diff by mtime (Date)', function() {
+        var date = new Date(10);
+        var result = entries.update([
+          { relativePath: 'a/b.js', mode: '0o666', size: 1, mtime: date },
+          { relativePath: 'b.js', mode: '0o666', size: 2, mtime: 1 }
+        ]);
+
+        expect(result).to.deep.equal([
+          { relativePath: 'a/b.js', mode: '0o666', size: 1, mtime: date }
         ]);
       });
 


### PR DESCRIPTION
Sometimes `mtime` is an instance of `Date` and other times it's a `Number`. This takes those type mismatches into account in order to avoid false positives during tree diffing.

Date instances can't be compared using `!==` or `===` since it compares their object identities, not their actual offset from the epoch.