### PR TITLE
patches now may include the entry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,30 +76,30 @@ FSTree.prototype.calculatePatch = function (otherFSTree) {
   tree.addEntries(fsAddTree.entries);
   var createOps = tree.preOrderDepthReducer(reduceAdditions, []);
 
-  var changes = this._findChanges(otherFSTree).map(function(change) {
-    return ['change', change];
+  var changes = this._findChanges(otherFSTree).map(function(entry) {
+    return ['change', entry.relativePath, entry];
   });
 
   return removeOps.concat(createOps).concat(changes);
 };
 
 FSTree.prototype._findChanges = function(nextTree) {
-  var a = this.intersection(nextTree).entries.values;
-  var b = nextTree.intersection(this).entries.values;
+  var next = this.intersection(nextTree).entries.values;
+  var previous = nextTree.intersection(this).entries.values;
 
-  if (a.length !== b.length) {
+  if (next.length !== previous.length) {
     throw new Error('EWUT');
   }
 
   var changes = [];
-  for (var i = 0; i < a.length; i++) {
-    if (needsUpdate(a[i], b[i])) {
-      changes.push(b[i].relativePath);
+  for (var i = 0; i < next.length; i++) {
+    if (needsUpdate(next[i], previous[i])) {
+      changes.push(next[i]);
     }
   }
 
   return changes;
-}
+};
 
 function needsUpdate(before, after) {
   if (before.isDirectory() && after.isDirectory()) {
@@ -121,7 +121,8 @@ function reduceAdditions(tree, acc) {
       child.isNew = false;
       ops.push([
         operation,
-        tree.pathForChild(childName)
+        tree.pathForChild(childName),
+        child.entry
       ]);
     }
 
@@ -141,7 +142,8 @@ function reduceRemovals(tree, acc) {
       var operation = child.isFile ? 'unlink' : 'rmdir';
       ops.push([
         operation,
-        tree.pathForChild(childName)
+        tree.pathForChild(childName),
+        undefined
       ]);
 
       delete tree.children[childName];

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -13,6 +13,9 @@ function Tree(entries, path, isNew) {
   this.isNew = isNew === true;
   this.path = path;
 
+  this.entry = new Entry(path || '', 0, 0);
+  this.entry.mode = 16877; // TODO: better Entry constructor..
+
   if (entries.size > 0) {
     this.addEntries(entries, this.isNew);
   }
@@ -64,7 +67,7 @@ Tree.prototype.addEntries = function (entries, _isNew) {
   var isNew = arguments.length > 1 ? arguments[1] : true;
 
   entries.forEach(function(entry) {
-    this.addEntry(entry, isNew);
+    this.addEntry(entry.relativePath, entry, isNew);
   }, this);
 };
 
@@ -76,11 +79,11 @@ function File(entry, isNew) {
   // TODO: error if entry is a directory
 }
 
-Tree.prototype.addEntry = function (entry, _isNew) {
-  var fileParts = entry.relativePath.split('/');
+Tree.prototype.addEntry = function (relativePath, entry, _isNew) {
+  var fileParts = relativePath.split('/');
   var current = fileParts.shift();
   var child = this.children[current];
-  var isNew = arguments.length > 1 ? arguments[1] : true;
+  var isNew = arguments.length > 2 ? arguments[2] : true;
 
   if (current === '') {
     return;
@@ -102,21 +105,22 @@ Tree.prototype.addEntry = function (entry, _isNew) {
 
     var tree = this.children[current];
     if (!tree) {
-      this.children[current] = new Tree(new Set([
-        new Entry( fileParts.join('/'), 0, ARBITRARY_START_OF_TIME)
-      ], 'relativePath'), this.pathForChild(current), isNew);
+      this.children[current] = new Tree(new Set([], 'relativePath'), this.pathForChild(current), isNew);
+      this.children[current].addEntry(fileParts.join('/'), entry, isNew);
     } else {
-      tree.addEntry(new Entry(fileParts.join('/'), entry.size, entry.mtime), isNew);
+      tree.addEntry(fileParts.join('/'), entry, isNew);
     }
   }
 };
 
 Tree.prototype.removeEntries = function (entries) {
-  entries.forEach(this.removeEntry, this);
+  entries.forEach(function(entry) {
+    this.removeEntry(entry.relativePath, entry);
+  }, this);
 };
 
-Tree.prototype.removeEntry = function (entry) {
-  var fileParts = chomp(entry.relativePath, '/').split('/');
+Tree.prototype.removeEntry = function (relativePath, entry) {
+  var fileParts = chomp(relativePath, '/').split('/');
   var current = fileParts.shift();
   var child = this.children[current];
 
@@ -133,9 +137,8 @@ Tree.prototype.removeEntry = function (entry) {
       throw new Error('Cannot remove directory from file');
     }
 
-    child.removeEntry(new Entry(fileParts.join('/'), null, null));
+    child.removeEntry(fileParts.join('/'), entry, null,  null);
   }
 };
-
 
 module.exports = Tree;


### PR DESCRIPTION
[operation, relativePath, entry]

entry is present IFF operation is change/create/mkdir
entry is not present for unlink or rmdir

This may change in the future, but it appears to kite the problem

This pr also reduces the number of `Entry` objects created, reusing existing ones, and ensuring the tree’s on entry objects have the actual relativePath rather then the tree node relativePath.