### PR TITLE
Throw error on duplicate entries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,19 @@ function FSTree(options) {
   if (options._entries) {
     this.entries = options._entries;
   } else {
-    this.entries = new Set(options.entries || [], 'relativePath');
+    var inputs = options.entries || [];
+
+    this.entries = new Set(inputs, 'relativePath');
+
+    if (this.entries.size !== inputs.length) {
+      var uniqInputs = new Set();
+      for (var i=0; i<inputs.length; ++i) {
+        if (uniqInputs.has(inputs[i].relativePath)) {
+          throw new Error('Duplicate Entry "' + inputs[i].relativePath + '"');
+        }
+        uniqInputs.add(inputs[i].relativePath);
+      }
+    }
   }
 }
 
@@ -73,7 +85,7 @@ FSTree.prototype.calculatePatch = function (otherFSTree) {
   tree.removeEntries(fsRemoveTree.entries);
   var removeOps = tree.postOrderDepthReducer(reduceRemovals, []);
 
-  // TODO: addEntries should be combined with th  preOrderDepthReducer and return addOps
+  // TODO: addEntries should be combined with the preOrderDepthReducer and return addOps
   tree.addEntries(fsAddTree.entries);
   var createOps = tree.preOrderDepthReducer(reduceAdditions, []);
 

--- a/tests/fs-tree-test.js
+++ b/tests/fs-tree-test.js
@@ -140,6 +140,15 @@ describe('FSTree', function() {
             ['create', 'bar/baz.js', file('bar/baz.js')],
           ]);
         });
+
+        it('throws an error for duplicate paths', function() {
+          expect(function () {
+            fsTree.calculatePatch(FSTree.fromEntries([
+              file('a/foo.js', { size: 1, mtime: 1 }),
+              file('a/foo.js', { size: 1, mtime: 2 }),
+            ]));
+          }).to.throw('Duplicate Entry "a/foo.js"');
+        });
       });
     });
 


### PR DESCRIPTION
```
FSTree.fromEntries([
  entry('a/foo.js', { size: 1, mtime: 1 }),
  entry('a/foo.js', { size: 2, mtime: 2 }),
]);
```
Picks an entry arbitrarily, at the whim of `fast-ordered-set`.  Change this
behavior so we throw an error rather than leave the result unspecified.