### PR TITLE
Differences in user-meta can trigger changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * performance improvements
 * directories in patches always end with a trailing slash
 * fixes various issues related to directory state transitions
+* directories can now receive `change` patches if user-supplied `meta` has
+  property changes
 
 # v0.4.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [BREAKING] entries must be lexigraphicaly sorted by relative path
 * [BREAKING] entries must include intermediate directories
-* [BREAKING] linkdir and unlinkdir no longer supported (BYOB metadata)
+* [BREAKING] linkdir and unlinkdir no longer supported (BYO metadata)
 * performance improvements
 * directories in patches always end with a trailing slash
 * fixes various issues related to directory state transitions

--- a/README.md
+++ b/README.md
@@ -125,18 +125,23 @@ different `size`s would still be illegal input).
 ## Change Calculation
 
 When a prior entry has a `relativePath` that matches that of a current entry, a
-change operation is included if any of the following properties differ between
+change operation is included for files if any of the following properties differ between
 the two entries:
 
   - `mode`
   - `size`
   - `mtime`
+  - `meta`
 
-Any other properties that differ between the two entries are treated as
-user-specific meta data and ignored.
+For directories, only `meta` is checked for changes.
+
+For the purposes of `meta` change calculation `null` and `undefined` are treated
+as `{}`.
+
+`meta` should be a flat object of simple properties (eg `{ rev: 1, link: true }`).
 
 This means that if you wanted to, for example, link directories instead of
-creating them, you could annotate your `entry` objects with `meta: { link: true
+creating them, you would annotate your `entry` objects with `meta: { link: true
 }` and check for this meta data when executing the patch returned by
 `calculatePatch`.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ The public API is:
     - `mode`
     - `size`
     - `mtime`
+- `FSTree.prototype.calculatePatch(newTree, isEqual)` calculate a patch against
+  `newTree`.  Optionally specify a custom `isEqual` (see Change Calculation).
 
 ## Input 
 
@@ -135,31 +137,34 @@ entry objects **must** contain the following properties:
 They must also implement the following API:
 
   - `isDirectory()` `true` *iff* this entry is a directory
-  - `equals(otherEntry)` `false` *iff* `otherEntry` should be considered
-    different from `entry` despite having the same values for `mode`, `size` and
-    `mtime`.
 
 ## Change Calculation
 
 When a prior entry has a `relativePath` that matches that of a current entry, a
-change operation is included for files if any of the following properties differ between
-the two entries:
+change operation is included if the new entry is different from the previous
+entry.  This is determined by calling `isEqual`, the optional second argument
+to `calculatePatch`.  If no `isEqual` is provided, a default `isEqual` is used.
+
+The default `isEqual` treats directories as always equal and files as different
+if any of the following properties have changed.
 
   - `mode`
   - `size`
   - `mtime`
 
-In addition to the above check, both file and directory entries are compared to
-their prior
-For directories, only `meta` is checked for changes.
+User specified `isEqual` will often want to use the default `isEqual`, so it is exported on `FSTree`.
 
-For the purposes of `meta` change calculation `null` and `undefined` are treated
-as `{}`.
+Example
 
-`meta` should be a flat object of simple properties (eg `{ rev: 1, link: true }`).
+```
+var defaultIsEqual = FSTtreeDiff.isEqual;
 
-This means that if you wanted to, for example, link directories instead of
-creating them, you would annotate your `entry` objects with `meta: { link: true
-}` and check for this meta data when executing the patch returned by
-`calculatePatch`.
+function isEqualCheckingMeta(a, b) {
+  return defaultIsEqual(a, b) && isMetaEqual(a, b);
+}
+
+function isMetaEqual(a, b) {
+  // ...
+}
+```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,23 @@ The public API is:
 must be sorted and path-unique (ie two entries with the same `relativePath` but
 different `size`s would still be illegal input).
 
+## Entry
+
+`FSTree.fromEntries` requires you to supply your own `Entry` objects.  Your
+entry objects **must** contain the following properties:
+
+  - `relativePath`
+  - `mode`
+  - `size`
+  - `mtime`
+
+They must also implement the following API:
+
+  - `isDirectory()` `true` *iff* this entry is a directory
+  - `equals(otherEntry)` `false` *iff* `otherEntry` should be considered
+    different from `entry` despite having the same values for `mode`, `size` and
+    `mtime`.
+
 ## Change Calculation
 
 When a prior entry has a `relativePath` that matches that of a current entry, a
@@ -131,8 +148,9 @@ the two entries:
   - `mode`
   - `size`
   - `mtime`
-  - `meta`
 
+In addition to the above check, both file and directory entries are compared to
+their prior
 For directories, only `meta` is checked for changes.
 
 For the purposes of `meta` change calculation `null` and `undefined` are treated

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -13,6 +13,8 @@ function Entry(relativePath, size, mtime) {
   this.mode = isDirectory ? DIRECTORY_MODE : 0;
   this.size = size;
   this.mtime = mtime;
+
+  this.meta = {};
 }
 
 Entry.isDirectory = function (entry) {

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -28,7 +28,3 @@ Entry.isFile = function (entry) {
 Entry.prototype.isDirectory = function() {
   return Entry.isDirectory(this);
 };
-
-Entry.prototype.equals = function equals(otherEntry) {
-  return true;
-}

--- a/lib/entry.js
+++ b/lib/entry.js
@@ -13,8 +13,6 @@ function Entry(relativePath, size, mtime) {
   this.mode = isDirectory ? DIRECTORY_MODE : 0;
   this.size = size;
   this.mtime = mtime;
-
-  this.meta = {};
 }
 
 Entry.isDirectory = function (entry) {
@@ -25,8 +23,12 @@ Entry.isFile = function (entry) {
   return !Entry.isDirectory(entry);
 };
 
-// TODO: remove this
+// required methods
+
 Entry.prototype.isDirectory = function() {
   return Entry.isDirectory(this);
 };
 
+Entry.prototype.equals = function equals(otherEntry) {
+  return true;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,15 @@ FSTree.prototype.forEach = function(fn, context) {
   this.entries.forEach(fn, context);
 };
 
-FSTree.prototype.calculatePatch = function(otherFSTree) {
+FSTree.prototype.calculatePatch = function(otherFSTree, isEqual) {
+  if (arguments.length > 1 && typeof isEqual !== 'function') {
+    throw new TypeError('calculatePatch\'s second argument must be a function');
+  }
+
+  if (typeof isEqual !== 'function') {
+    isEqual = FSTree.defaultIsEqual;
+  }
+
   var ours = this.entries;
   var theirs = otherFSTree.entries;
   var operations = [];
@@ -91,7 +99,7 @@ FSTree.prototype.calculatePatch = function(otherFSTree) {
       j++;
       operations.push(addCommand(y));
     } else {
-      if (needsUpdate(x, y)) {
+      if (!isEqual(x, y)) {
         command = updateCommand(y);
 
         if (x.isDirectory()) {
@@ -118,6 +126,23 @@ FSTree.prototype.calculatePatch = function(otherFSTree) {
   return operations.concat(removals.reverse());
 };
 
+FSTree.defaultIsEqual = function defaultIsEqual(entryA, entryB) {
+  if (entryA.isDirectory() && entryB.isDirectory()) {
+    // ignore directory changes by default
+    return true;
+  }
+
+  var equal = entryA.size === entryB.size &&
+       +entryA.mtime === +entryB.mtime &&
+       entryA.mode === entryB.mode;
+
+  if (!equal) {
+    debug('invalidation reason: \nbefore %o\n entryB %o', entryA, entryB);
+  }
+
+  return equal;
+};
+
 function addCommand(entry) {
   return [entry.isDirectory() ? 'mkdir' : 'create', entry.relativePath, entry];
 }
@@ -128,27 +153,4 @@ function removeCommand(entry) {
 
 function updateCommand(entry) {
   return ['change', entry.relativePath, entry];
-}
-
-function needsUpdate(before, after) {
-  var invalidate;
-
-  if (before.isDirectory() && after.isDirectory()) {
-    invalidate = false;
-  } else {
-    invalidate = before.size !== after.size ||
-         +before.mtime !== +after.mtime ||
-         before.mode !== after.mode;
-  }
-
-  if (invalidate) {
-    debug('invalidation reason: \nbefore %o\n after %o', before, after);
-  }
-
-  if (!invalidate) {
-    // entry appears to have not changed, but allow user to override
-    invalidate = (after.equals(before) === false);
-  }
-
-  return invalidate;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,13 +123,33 @@ function updateCommand(entry) {
 }
 
 function needsUpdate(before, after) {
-  if (before.isDirectory() && after.isDirectory()) {
-    return false;
-  }
+  var invalidate;
 
-  var invalidate = before.size !== after.size ||
+  if (before.isDirectory() && after.isDirectory()) {
+    invalidate = false;
+  } else {
+    invalidate = before.size !== after.size ||
          +before.mtime !== +after.mtime ||
          before.mode !== after.mode;
+  }
+
+  if (!invalidate) {
+    var beforeMeta = before.meta;
+    var afterMeta = after.meta;
+    var beforeMetaKeys = beforeMeta ? Object.keys(beforeMeta) : [];
+    var afterMetaKeys = afterMeta ? Object.keys(afterMeta) : [];
+
+    if (beforeMetaKeys.length !== afterMetaKeys.length) {
+      invalidate = true;
+    } else {
+      for (var i=0; i<beforeMetaKeys.length; ++i) {
+        if (beforeMeta[beforeMetaKeys[i]] !== afterMeta[afterMetaKeys[i]]) {
+          invalidate = true;
+          break;
+        }
+      }
+    }
+  }
 
   if (invalidate) {
     debug('invalidation reason: \nbefore %o\n after %o', before, after);

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,6 +65,8 @@ FSTree.prototype.calculatePatch = function(otherFSTree) {
 
   var removals = [];
 
+  var command;
+
   while (i < ours.length && j < theirs.length) {
     var x = ours[i];
     var y = theirs[j];
@@ -73,7 +75,7 @@ FSTree.prototype.calculatePatch = function(otherFSTree) {
       // ours
       i++;
 
-      var command = removeCommand(x);
+      command = removeCommand(x);
 
       if (x.isDirectory()) {
         removals.push(command);
@@ -90,7 +92,13 @@ FSTree.prototype.calculatePatch = function(otherFSTree) {
       operations.push(addCommand(y));
     } else {
       if (needsUpdate(x, y)) {
-        operations.push(updateCommand(y));
+        command = updateCommand(y);
+
+        if (x.isDirectory()) {
+          removals.push(command);
+        } else {
+          operations.push(command);
+        }
       }
       // both are the same
       i++; j++;

--- a/lib/index.js
+++ b/lib/index.js
@@ -133,26 +133,13 @@ function needsUpdate(before, after) {
          before.mode !== after.mode;
   }
 
-  if (!invalidate) {
-    var beforeMeta = before.meta;
-    var afterMeta = after.meta;
-    var beforeMetaKeys = beforeMeta ? Object.keys(beforeMeta) : [];
-    var afterMetaKeys = afterMeta ? Object.keys(afterMeta) : [];
-
-    if (beforeMetaKeys.length !== afterMetaKeys.length) {
-      invalidate = true;
-    } else {
-      for (var i=0; i<beforeMetaKeys.length; ++i) {
-        if (beforeMeta[beforeMetaKeys[i]] !== afterMeta[afterMetaKeys[i]]) {
-          invalidate = true;
-          break;
-        }
-      }
-    }
-  }
-
   if (invalidate) {
     debug('invalidation reason: \nbefore %o\n after %o', before, after);
+  }
+
+  if (!invalidate) {
+    // entry appears to have not changed, but allow user to override
+    invalidate = (after.equals(before) === false);
   }
 
   return invalidate;

--- a/tests/fs-tree-test.js
+++ b/tests/fs-tree-test.js
@@ -29,10 +29,34 @@ describe('FSTree', function() {
     this.size = options.size;
     this.mtime = options.mtime;
 
-    this.meta = options.meta;
+    if (options.meta) {
+      this.meta = options.meta;
+    }
   }
 
   MockEntry.prototype.isDirectory = Entry.prototype.isDirectory;
+  MockEntry.prototype.equals = function (otherEntry){
+    var meta = this.meta;
+    var otherMeta = otherEntry.meta;
+    var metaKeys = meta ? Object.keys(meta) : [];
+    var otherMetaKeys = otherMeta ? Object.keys(otherMeta) : [];
+
+    if (metaKeys.length !== Object.keys(otherMetaKeys).length) {
+      return false;
+    } else {
+      for (var i=0; i<metaKeys.length; ++i) {
+        if (meta[metaKeys[i]] !== otherMeta[metaKeys[i]]) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  };
+  // This is only to make `equals` ignored during `deep.equal` against entries
+  // `fromPaths`
+  Entry.prototype.equals = MockEntry.prototype.equals;
+
 
   function file(relativePath, options) {
     return entry(merge({ relativePath: relativePath }, options));
@@ -51,7 +75,7 @@ describe('FSTree', function() {
       mode: options.mode || 0,
       size: options.size || 0,
       mtime: options.mtime || 0,
-      meta: options.meta || {},
+      meta: options.meta,
     });
   }
 


### PR DESCRIPTION
This is primarily useful to support linking directories, and in particular to handle the case of a previously copied directory changing to a linked directory (or vice-versa), as can happen in broccolijs/broccoli-merge-trees when a directory initially exists in multiple input paths, but during a rebuild exists in exactly one input path.