### PR TITLE
Add option sortAndExpand

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,41 @@ The public API is:
 ## Input 
 
 `FSTree.fromPaths` and `FSTree.fromEntries` both validate their inputs.  Inputs
-must be sorted and path-unique (ie two entries with the same `relativePath` but
-different `size`s would still be illegal input).
+must be sorted, path-unique (ie two entries with the same `relativePath` but
+different `size`s would still be illegal input) and include intermediate
+directories.
+
+For example, the following input is **invaild**
+
+```js
+FSTree.fromPaths([
+  // => missing a/ and a/b/
+  'a/b/c.js'
+]);
+```
+
+To have FSTree sort and expand (include intermediate directories) for you, add
+the option `sortAndExpand`).
+
+```js
+FStree.fromPaths([
+	'a/b/q/r/bar.js',
+	'a/b/c/d/foo.js',
+], { sortAndExpand: true });
+
+// The above is equivalent to
+
+FSTree.fromPaths([
+	'a/',
+	'a/b/',
+	'a/b/c/',
+	'a/b/c/d/',
+	'a/b/c/d/foo.js',
+	'a/b/q/',
+	'a/b/q/r/',
+	'a/b/q/r/bar.js',
+]);
+```
 
 ## Entry
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,9 @@
 
 var Entry = require('./entry');
 var debug = require('debug')('fs-tree-diff:');
+var util = require('./util');
+var sortAndExpand = util.sortAndExpand;
+var validateSortedUnique = util.validateSortedUnique;
 
 var ARBITRARY_START_OF_TIME = 0;
 
@@ -10,38 +13,37 @@ module.exports = FSTree;
 function FSTree(options) {
   options = options || {};
 
-  this.entries = options.entries || [];
-  validateSortedUnique(this.entries);
-}
+  var entries = options.entries || [];
 
-function validateSortedUnique(entries) {
-  for (var i = 1; i < entries.length; i++) {
-    var previous = entries[i - 1].relativePath;
-    var current = entries[i].relativePath;
-
-    if (previous < current) {
-      continue;
-    } else {
-      throw new Error('expected entries[' + (i -1) + ']: `' + previous +
-                      '` to be < entries[' + i + ']: `' + current + '`, but was not. Ensure your input is sorted and has no duplicate paths');
-    }
+  if (options.sortAndExpand) {
+    sortAndExpand(entries);
+  } else {
+    validateSortedUnique(entries);
   }
+
+  this.entries = entries;
 }
 
-FSTree.fromPaths = function(paths) {
+FSTree.fromPaths = function(paths, options) {
+  if (typeof options !== 'object') { options = {}; }
+
   var entries = paths.map(function(path) {
     return new Entry(path, 0, ARBITRARY_START_OF_TIME);
   });
 
   return new FSTree({
     entries: entries,
+    sortAndExpand: options.sortAndExpand,
   });
 };
 
 
-FSTree.fromEntries = function(entries) {
+FSTree.fromEntries = function(entries, options) {
+  if (typeof options !== 'object') { options = {}; }
+
   return new FSTree({
-    entries: entries
+    entries: entries,
+    sortAndExpand: options.sortAndExpand,
   });
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,124 @@
+'use strict';
+
+var Entry = require('./entry');
+
+function validateSortedUnique(entries) {
+  for (var i = 1; i < entries.length; i++) {
+    var previous = entries[i - 1].relativePath;
+    var current = entries[i].relativePath;
+
+    if (previous < current) {
+      continue;
+    } else {
+      throw new Error('expected entries[' + (i -1) + ']: `' + previous +
+                      '` to be < entries[' + i + ']: `' + current + '`, but was not. Ensure your input is sorted and has no duplicate paths');
+    }
+  }
+}
+
+
+function commonPrefix(a, b, term) {
+  var max = Math.min(a.length, b.length);
+  var end = 0;
+
+  for(var i = 0; i < max; ++i) {
+    if (a[i] !== b[i]) {
+      break;
+    } else if (a[i] === term) {
+      end = i;
+    }
+  }
+
+  return a.substr(0, end + 1);
+}
+
+function basename(entry) {
+  var path = entry.relativePath;
+  var end = path.length - 2;
+  for(var i = end; i >= 0; --i) {
+    if (path[i] === '/') {
+      return path.substr(0, i + 1);
+    }
+  }
+
+  return '';
+}
+
+function computeImpliedEntries(basePath, relativePath) {
+  var rv = [];
+
+  for (var i=0; i<relativePath.length; ++i) {
+    if (relativePath[i] === '/') {
+      var path = basePath + relativePath.substr(0, i + 1);
+      rv.push(new Entry(path, 0, 0));
+    }
+  }
+
+  return rv;
+}
+
+function compareByRelativePath(entryA, entryB) {
+  var pathA = entryA.relativePath;
+  var pathB = entryB.relativePath;
+
+  if (pathA < pathB) {
+    return -1;
+  } else if (pathA > pathB) {
+    return 1;
+  }
+
+  return 0;
+}
+
+function sortAndExpand(entries) {
+  entries.sort(compareByRelativePath);
+
+  var path = '';
+
+  for (var i=0; i<entries.length; ++i) {
+    var entry = entries[i];
+
+    // update our path eg
+    //    path = a/b/c/d/
+    //    entry = a/b/q/r/s/
+    //    path' = a/b/
+    path = commonPrefix(path, entry.relativePath, '/');
+
+    // a/b/ -> a/
+    // a/b  -> a/
+    var base = basename(entry);
+    // base - path
+    var entryBaseSansCommon = base.substr(path.length);
+    // determine what intermediate directories are missing eg
+    //    path = a/b/
+    //    entryBaseSansCommon = c/d/e/
+    //    impliedEntries = [a/b/c/, a/b/c/d/, a/b/c/d/e/]
+    var impliedEntries = computeImpliedEntries(path, entryBaseSansCommon);
+
+    // actually add our implied entries to entries
+    if (impliedEntries.length > 0) {
+      entries.splice.apply(entries, [i, 0].concat(impliedEntries));
+      i += impliedEntries.length;
+    }
+
+    // update path.  Now that we've created all the intermediate directories, we
+    // don't need to recreate them for subsequent entries.
+    if (entry.isDirectory()) {
+      path = entry.relativePath;
+    } else {
+      path = base;
+    }
+  }
+
+  return entries;
+}
+
+module.exports = {
+  validateSortedUnique: validateSortedUnique,
+  sortAndExpand: sortAndExpand,
+
+  // exported for testing
+  _commonPrefix: commonPrefix,
+  _basename: basename,
+  _computeImpliedEntries: computeImpliedEntries,
+};

--- a/tests/fs-tree-test.js
+++ b/tests/fs-tree-test.js
@@ -82,6 +82,12 @@ describe('FSTree', function() {
     });
   }
 
+  function by(property) {
+    return function pluckProperty(item) {
+      return item[property];
+    };
+  }
+
   it('can be instantiated', function() {
     expect(new FSTree()).to.be.an.instanceOf(FSTree);
   });
@@ -109,6 +115,61 @@ describe('FSTree', function() {
             'a',
           ]);
         }).to.throw('expected entries[0]: `b` to be < entries[1]: `a`, but was not. Ensure your input is sorted and has no duplicate paths');
+      });
+    });
+
+    describe('options', function() {
+      describe('sortAndExpand', function() {
+        it('sorts input entries', function() {
+          fsTree = FSTree.fromPaths([
+            'foo/',
+            'foo/a.js',
+            'bar/',
+            'bar/b.js',
+          ], { sortAndExpand: true });
+
+          expect(fsTree.entries.map(by('relativePath'))).to.deep.equal([
+            'bar/',
+            'bar/b.js',
+            'foo/',
+            'foo/a.js',
+          ]);
+        });
+
+        it('expands intermediate directories implied by input entries', function() {
+          fsTree = FSTree.fromPaths([
+            'a/b/q/r/bar.js',
+            'a/b/c/d/foo.js',
+          ], { sortAndExpand: true });
+
+          expect(fsTree.entries).to.deep.equal([
+            directory('a/'),
+            directory('a/b/'),
+            directory('a/b/c/'),
+            directory('a/b/c/d/'),
+            file('a/b/c/d/foo.js'),
+            directory('a/b/q/'),
+            directory('a/b/q/r/'),
+            file('a/b/q/r/bar.js'),
+          ]);
+        });
+
+        it('does not mutate its input', function() {
+          var paths = [
+            'foo/',
+            'foo/a.js',
+            'bar/',
+            'bar/b.js',
+          ];
+          fsTree = FSTree.fromPaths(paths, { sortAndExpand: true });
+
+          expect(paths).to.deep.equal([
+            'foo/',
+            'foo/a.js',
+            'bar/',
+            'bar/b.js',
+          ]);
+        });
       });
     });
 

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,0 +1,77 @@
+'use strict';
+
+var expect = require('chai').expect;
+var util = require('../lib/util');
+var Entry = require('../lib/entry');
+
+var commonPrefix = util._commonPrefix;
+var basename = util._basename;
+var computeImpliedEntries = util._computeImpliedEntries;
+var sortAndExpand = util.sortAndExpand;
+
+require('chai').config.truncateThreshold = 0;
+
+
+describe('commonPrefix', function() {
+  it('computes the common prefix between two strings', function() {
+    expect(commonPrefix('a/b/c/', 'a/b/c/d/e/f/', '/')).to.equal('a/b/c/');
+  });
+
+  it('strips the suffix (of the common prefix) after the last occurrence of the terminal character', function() {
+    expect(commonPrefix('a/b/c/ohai', 'a/b/c/obai', '/')).to.equal('a/b/c/');
+  });
+});
+
+describe('basename', function() {
+  it('computes the basename of files', function() {
+    expect(basename(new Entry('a/b/c'))).to.equal('a/b/');
+  });
+
+  it('computes the basename of directories', function() {
+    expect(basename(new Entry('a/b/c/'))).to.equal('a/b/');
+  });
+});
+
+describe('computeImpliedEntries', function() {
+  it('computes implied entries', function() {
+    var entries = computeImpliedEntries('a/b/', 'c/d/e/');
+    expect(entries).to.deep.equal([
+      new Entry('a/b/c/', 0, 0),
+      new Entry('a/b/c/d/', 0, 0),
+      new Entry('a/b/c/d/e/', 0, 0),
+    ]);
+  });
+});
+
+describe('sortAndExpand', function() {
+  it('sorts and expands entries in place', function() {
+    var entries = [
+      new Entry('a/b/q/r/bar.js'),
+      new Entry('a/b/c/d/foo.js'),
+    ];
+
+    var sortedAndExpandedEntries = sortAndExpand(entries);
+
+    expect(entries).to.equal(sortedAndExpandedEntries);
+    expect(sortedAndExpandedEntries.map(function(e) { return e.relativePath;})).to.deep.equal([
+      'a/',
+      'a/b/',
+      'a/b/c/',
+      'a/b/c/d/',
+      'a/b/c/d/foo.js',
+      'a/b/q/',
+      'a/b/q/r/',
+      'a/b/q/r/bar.js',
+    ]);
+    expect(sortedAndExpandedEntries).to.deep.equal([
+      new Entry('a/', 0, 0),
+      new Entry('a/b/', 0, 0),
+      new Entry('a/b/c/', 0, 0),
+      new Entry('a/b/c/d/', 0, 0),
+      new Entry('a/b/c/d/foo.js'),
+      new Entry('a/b/q/', 0, 0),
+      new Entry('a/b/q/r/', 0, 0),
+      new Entry('a/b/q/r/bar.js'),
+    ]);
+  });
+});


### PR DESCRIPTION
## Todo

- [ ] don't mutate input in `fromEntries`
- [ ] export `FSTree.sortAndExpand`

## Summary

Fix #18

```js
FSTree.fromPaths([
  'a/b/q/r/bar.js',
  'a/b/c/d/foo.js',
], { sortAndExpand: true })

// is equivalent to

FSTree.fromPaths([
  'a/',
  'a/b/',
  'a/b/c/',
  'a/b/c/d/',
  'a/b/c/d/foo.js',
  'a/b/q/',
  'a/b/q/r/',
  'a/b/q/r/bar.js',
]);
```

This option is available to both `fromPaths` and `fromEntries`.