### PR TITLE
Note another breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [BREAKING] entries must be lexigraphicaly sorted by relative path
 * [BREAKING] entries must include intermediate directories
 * [BREAKING] linkdir and unlinkdir no longer supported (BYO metadata)
+* [BREAKING] `unlink` and `rmdir` operations are now passed the entry
 * performance improvements
 * directories in patches always end with a trailing slash
 * fixes various issues related to directory state transitions


### PR DESCRIPTION
`unlink` and `rmdir` operations are passed the entry: this broke a test in
ember-cli as the liverelaod server's `isDirectory` filter implicitly filtered
these operations because they had no entry.