### PR TITLE
Add entries to an existing tree.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,15 @@ The public API is:
     - `mtime`
 - `FSTree.prototype.calculatePatch(newTree, isEqual)` calculate a patch against
   `newTree`.  Optionally specify a custom `isEqual` (see Change Calculation).
+- `FSTree.prototype.addEntries(entries, options)` adds entries to an
+  existing tree. Options are the same as for `FSTree.fromEntries`.
+- `FSTree.prototype.addPaths(paths, options)` adds paths to an
+  existing tree. Options are the same as for `FSTree.fromPaths`.
 
 ## Input 
 
-`FSTree.fromPaths` and `FSTree.fromEntries` both validate their inputs.  Inputs
+`FSTree.fromPaths`, `FSTree.fromEntries`, `FSTree.prototype.addPaths`,
+and `FSTree.prototype.addEntries` all validate their inputs.  Inputs
 must be sorted, path-unique (ie two entries with the same `relativePath` but
 different `size`s would still be illegal input) and include intermediate
 directories.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,11 @@ The public API is:
   `newTree`.  Optionally specify a custom `isEqual` (see Change Calculation).
 - `FSTree.prototype.addEntries(entries, options)` adds entries to an
   existing tree. Options are the same as for `FSTree.fromEntries`.
+  Entries added with the same path will overwrite any existing entries.
 - `FSTree.prototype.addPaths(paths, options)` adds paths to an
   existing tree. Options are the same as for `FSTree.fromPaths`.
+  If entries already exist for any of the paths added, those entries will
+  be updated.
 
 ## Input 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,6 +53,39 @@ Object.defineProperty(FSTree.prototype, 'size', {
   }
 });
 
+FSTree.prototype.addEntries = function(entries, options) {
+  if (!Array.isArray(entries)) {
+    throw new TypeError('entries must be an array');
+  }
+  if (options && options.sortAndExpand) {
+    sortAndExpand(entries);
+  } else {
+    validateSortedUnique(entries);
+  }
+  var fromIndex = 0;
+  var toIndex = 0;
+  while (fromIndex < entries.length) {
+    while (toIndex < this.entries.length &&
+           this.entries[toIndex].relativePath < entries[fromIndex].relativePath) {
+      toIndex++;
+    }
+    if (toIndex < this.entries.length &&
+        this.entries[toIndex].relativePath === entries[fromIndex].relativePath) {
+      this.entries.splice(toIndex, 1, entries[fromIndex++]);
+    } else {
+      this.entries.splice(toIndex++, 0, entries[fromIndex++]);
+    }
+  }
+};
+
+FSTree.prototype.addPaths = function(paths, options) {
+  var entries = paths.map(function(path) {
+    return new Entry(path, 0, ARBITRARY_START_OF_TIME);
+  });
+
+  this.addEntries(entries, options);
+}
+
 FSTree.prototype.forEach = function(fn, context) {
   this.entries.forEach(fn, context);
 };


### PR DESCRIPTION
This commit adds `FSTree.prototype.addPaths` and
`FSTree.prototype.addEntries` which efficiently add multiple entries
into a existing sorted and expanded tree. The `sortAndExpand` option
is accepted for situations where the input is not well formed.