### PR TITLE
Fix calculatePatch to unlink files first when we are to remove a directory.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,6 +135,7 @@ FSTree.prototype.calculatePatch = function(otherFSTree, isEqual) {
   var j = 0;
 
   var removals = [];
+  var preCleanup = [];
 
   var command;
 
@@ -153,7 +154,7 @@ FSTree.prototype.calculatePatch = function(otherFSTree, isEqual) {
       } else {
         // pre-cleanup file removals should occure in-order, this ensures file
         // -> directory transforms work correctly
-        additions.push(command);
+        preCleanup.push(command);
       }
 
       // remove additions
@@ -187,7 +188,7 @@ FSTree.prototype.calculatePatch = function(otherFSTree, isEqual) {
   }
 
   // operations = removals (in reverse) then additions
-  return removals.reverse().concat(additions);
+  return preCleanup.concat(removals.reverse().concat(additions));
 };
 
 FSTree.prototype.calculateAndApplyPatch = function(otherFSTree, input, output, delegate) {

--- a/tests/fs-tree-test.js
+++ b/tests/fs-tree-test.js
@@ -607,10 +607,10 @@ describe('FSTree', function() {
             'bar/',
             'bar/two.js'
           ]))).to.deep.equal([
+            ['unlink', 'bar/one.js', file('bar/one.js')],
             ['unlink', 'foo/two.js', file('foo/two.js')],
             ['unlink', 'foo/one.js', file('foo/one.js')],
             ['rmdir',  'foo/',       directory('foo/')],
-            ['unlink', 'bar/one.js', file('bar/one.js')],
           ]);
         });
       });
@@ -621,11 +621,11 @@ describe('FSTree', function() {
             'bar/',
             'bar/three.js'
           ]))).to.deep.equal([
+            ['unlink', 'bar/one.js',    file('bar/one.js')],
             ['unlink', 'foo/two.js',    file('foo/two.js')],
             ['unlink', 'foo/one.js',    file('foo/one.js')],
             ['rmdir',  'foo/',          directory('foo/')],
             ['unlink', 'bar/two.js',    file('bar/two.js')],
-            ['unlink', 'bar/one.js',    file('bar/one.js')],
             ['create', 'bar/three.js',  file('bar/three.js')],
           ]);
         });
@@ -830,6 +830,21 @@ describe('FSTree', function() {
         ]);
       });
 
+      it('always remove files first if dir also needs to be removed', function() {
+        var newTree = new FSTree({
+          entries: [
+            entry(directory('parent/'))
+          ]
+        });
+
+        var result = fsTree.calculatePatch(newTree);
+
+        expect(result).to.deep.equal([
+          ['unlink', 'parent/subdir/a.js',  file('parent/subdir/a.js')],
+          ['rmdir', 'parent/subdir/',       directory('parent/subdir/')]
+        ]);
+      });
+
       it('renaming a subdir does not recreate parent', function () {
         var newTree = new FSTree({
           entries: [
@@ -842,8 +857,8 @@ describe('FSTree', function() {
         var result = fsTree.calculatePatch(newTree);
 
         expect(result).to.deep.equal([
-          ['rmdir', 'parent/subdir/',       directory('parent/subdir/')],
           ['unlink', 'parent/subdir/a.js',  file('parent/subdir/a.js')],
+          ['rmdir', 'parent/subdir/',       directory('parent/subdir/')],
           ['mkdir', 'parent/subdir2/',      directory('parent/subdir2/')],
           ['create', 'parent/subdir2/a.js', file('parent/subdir2/a.js')],
         ]);


### PR DESCRIPTION
When directory is to be removed the files in it should be subject to unlinking first as `fs.rmdirSync` used by `broccoli-funnel` would only deal with empty directories and would raise an Error as a result. The bug seems to be introduced in cb0f431 as previously unlinking files was actually pushed to `additions/operations` Array in order to be executed before removals concatenation.

Probably related - #51 