### PR TITLE
[Cleanup] removals in reverse order then additions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,6 @@ FSTree.prototype.calculatePatch = function(otherFSTree, isEqual) {
   var j = 0;
 
   var removals = [];
-  var preCleanup = [];
 
   var command;
 
@@ -147,15 +146,7 @@ FSTree.prototype.calculatePatch = function(otherFSTree, isEqual) {
       // ours
       i++;
 
-      command = removeCommand(x);
-
-      if (x.isDirectory()) {
-        removals.push(command);
-      } else {
-        // pre-cleanup file removals should occure in-order, this ensures file
-        // -> directory transforms work correctly
-        preCleanup.push(command);
-      }
+      removals.push(removeCommand(x));
 
       // remove additions
     } else if (x.relativePath > y.relativePath) {
@@ -188,7 +179,7 @@ FSTree.prototype.calculatePatch = function(otherFSTree, isEqual) {
   }
 
   // operations = removals (in reverse) then additions
-  return preCleanup.concat(removals.reverse().concat(additions));
+  return removals.reverse().concat(additions);
 };
 
 FSTree.prototype.calculateAndApplyPatch = function(otherFSTree, input, output, delegate) {

--- a/tests/fs-tree-test.js
+++ b/tests/fs-tree-test.js
@@ -588,7 +588,6 @@ describe('FSTree', function() {
       });
     });
 
-
     context('from a non-empty tree', function() {
       beforeEach( function() {
         fsTree = FSTree.fromPaths([
@@ -607,25 +606,25 @@ describe('FSTree', function() {
             'bar/',
             'bar/two.js'
           ]))).to.deep.equal([
-            ['unlink', 'bar/one.js', file('bar/one.js')],
             ['unlink', 'foo/two.js', file('foo/two.js')],
             ['unlink', 'foo/one.js', file('foo/one.js')],
             ['rmdir',  'foo/',       directory('foo/')],
+            ['unlink', 'bar/one.js', file('bar/one.js')],
           ]);
         });
       });
 
       context('with removals and additions', function() {
-        it('reduces the rm operations', function() {
+        it('works', function() {
           expect(fsTree.calculatePatch(FSTree.fromPaths([
             'bar/',
             'bar/three.js'
           ]))).to.deep.equal([
-            ['unlink', 'bar/one.js',    file('bar/one.js')],
             ['unlink', 'foo/two.js',    file('foo/two.js')],
             ['unlink', 'foo/one.js',    file('foo/one.js')],
             ['rmdir',  'foo/',          directory('foo/')],
             ['unlink', 'bar/two.js',    file('bar/two.js')],
+            ['unlink', 'bar/one.js',    file('bar/one.js')],
             ['create', 'bar/three.js',  file('bar/three.js')],
           ]);
         });


### PR DESCRIPTION
Originally our algorithm was simple. Removal in reverse order, then additions. Unfortunately, it was implemented incorrectly. When we fixed a bug here, we add unneeded complexity… introducing another bug. 2cffc919 fixes the bug we introduced, and obvious that our original algorithm (just implemented correctly) was actually fine if we just implemented it correctly.