### PR TITLE
Updating changes to do sort & expand operations when srcTree is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ var next = FSTree.fromPaths([
 ]);
 
 current.calculatePatch(next) === [
-  ['unlink', 'a.js'],
-  ['create', 'b.js']
+  ['unlink', 'a.js', entryA],
+  ['create', 'b.js', entryB]
 ];
 ```
 
@@ -71,11 +71,11 @@ Now, the above examples do not demonstrate `change` operations. This is because
 when providing only paths, we do not have sufficient information to check if
 one entry is merely different from another with the same relativePath.
 
-For this, FSTree supports more complex input structure. To demonstrate, We will
-use the [walk-sync](https://github.com/joliss/node-walk-sync) module.
-**(note: `walk-sync >= 0.2.7` is required`)** Which provides higher fidelity
-input, allowing FSTree to also detect changes. More on what an
-[entry from walkSync.entries is](https://github.com/joliss/node-walk-sync#entries)
+For this, FSTree supports more complex input structure. To demonstrate, we
+will use the [walk-sync](https://github.com/joliss/node-walk-sync) module,
+which provides higher fidelity input, allowing FSTree to also detect changes.
+(See also the documentation for
+[walkSync.entries](https://github.com/joliss/node-walk-sync#entries).)
 
 ```js
 var walkSync = require('walk-sync');
@@ -143,11 +143,11 @@ assume that the base directory has not changed.
 
 `FSTree.fromPaths`, `FSTree.fromEntries`, `FSTree.prototype.addPaths`,
 and `FSTree.prototype.addEntries` all validate their inputs.  Inputs
-must be sorted, path-unique (ie two entries with the same `relativePath` but
+must be sorted, path-unique (i.e. two entries with the same `relativePath` but
 different `size`s would still be illegal input) and include intermediate
 directories.
 
-For example, the following input is **invaild**
+For example, the following input is **invalid**
 
 ```js
 FSTree.fromPaths([

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ var next = FSTree.fromPaths([
 ]);
 
 current.calculatePatch(next) === [
-  ['unlink', 'a.js', entryA],
-  ['create', 'b.js', entryB]
+  ['unlink', 'a.js'],
+  ['create', 'b.js']
 ];
 ```
 
@@ -71,11 +71,11 @@ Now, the above examples do not demonstrate `change` operations. This is because
 when providing only paths, we do not have sufficient information to check if
 one entry is merely different from another with the same relativePath.
 
-For this, FSTree supports more complex input structure. To demonstrate, we
-will use the [walk-sync](https://github.com/joliss/node-walk-sync) module,
-which provides higher fidelity input, allowing FSTree to also detect changes.
-(See also the documentation for
-[walkSync.entries](https://github.com/joliss/node-walk-sync#entries).)
+For this, FSTree supports more complex input structure. To demonstrate, We will
+use the [walk-sync](https://github.com/joliss/node-walk-sync) module.
+**(note: `walk-sync >= 0.2.7` is required`)** Which provides higher fidelity
+input, allowing FSTree to also detect changes. More on what an
+[entry from walkSync.entries is](https://github.com/joliss/node-walk-sync#entries)
 
 ```js
 var walkSync = require('walk-sync');
@@ -143,11 +143,11 @@ assume that the base directory has not changed.
 
 `FSTree.fromPaths`, `FSTree.fromEntries`, `FSTree.prototype.addPaths`,
 and `FSTree.prototype.addEntries` all validate their inputs.  Inputs
-must be sorted, path-unique (i.e. two entries with the same `relativePath` but
+must be sorted, path-unique (ie two entries with the same `relativePath` but
 different `size`s would still be illegal input) and include intermediate
 directories.
 
-For example, the following input is **invalid**
+For example, the following input is **invaild**
 
 ```js
 FSTree.fromPaths([

--- a/lib/index.js
+++ b/lib/index.js
@@ -404,8 +404,8 @@ FSTree.prototype.match = function(globs) {
   });
 };
 
-function getDirDepth(path){
-  return path.split('/').length -1;
+function getDirDepth(dirPath){
+  return dirPath.split(path.sep).length-1;
 }
 
 FSTree.prototype.changes = function() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -441,8 +441,8 @@ FSTree.prototype.changes = function() {
         //     subdir2 /
         //
         //    when the above happens, we should remove subdir1 & subsubdir1
-        const topFilteredEntry = filteredEntries[filteredEntries.length-1];
-        if (isDirectory(entry) && isDirectory(topEntry)) {
+        let topFilteredEntry = filteredEntries[filteredEntries.length-1];
+        if (isDirectory(entry) && isDirectory(topFilteredEntry)) {
           while (filteredEntries.length !== 0 && getDirDepth(topFilteredEntry.relativePath) >= getDirDepth(entry.relativePath)) {
             filteredEntries.pop();
             topFilteredEntry = filteredEntries[filteredEntries.length-1];

--- a/lib/index.js
+++ b/lib/index.js
@@ -442,7 +442,7 @@ FSTree.prototype.changes = function() {
         //
         //    when the above happens, we should remove subdir1 & subsubdir1
         let topFilteredEntry = filteredEntries[filteredEntries.length-1];
-        if (isDirectory(entry) && isDirectory(topFilteredEntry)) {
+        if (topFilteredEntry !== undefined && isDirectory(topFilteredEntry) && isDirectory(entry)) {
           while (filteredEntries.length !== 0 && getDirDepth(topFilteredEntry.relativePath) >= getDirDepth(entry.relativePath)) {
             filteredEntries.pop();
             topFilteredEntry = filteredEntries[filteredEntries.length-1];

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ function FSTree(options) {
 
   this.parent = options.parent || null;
   this.cwd = options.cwd || '';
-  this.files = options.files ||  [];
+  this.files = options.files ||  null;
   this.exclude = options.exclude || [];
   this.include = options.include || [];
 
@@ -404,12 +404,81 @@ FSTree.prototype.match = function(globs) {
   });
 };
 
+function getDirDepth(path){
+  return path.split('/').length -1;
+}
+
 FSTree.prototype.changes = function() {
-  return this._changes.filter(change => {
-    return filterMatches(change[1], this.cwd, this.files, this.include, this.exclude);
-  }).map(change => {
-    return [change[0], change[1].replace(`${this.cwd}`, ''), change[2]];
-  });
+  this._ensureEntriesPopulated();
+  var patches;
+
+  if (this.srcTree) {
+    let filteredEntries = [];
+    let dirStack = [];
+    let dirDepth = 0;
+    // filter this.entries with files, include and exclude
+    // including sort and expand of the matched entries
+    this.entries.map(entry => {
+      const filterMatched = filterMatches(entry.relativePath, this.cwd, this.files, this.include, this.exclude);
+      if (filterMatched) {
+        // if we find a match, push all the dir entries in dirStack
+        // into filteredEntries
+        let i;
+        for (i = 0; i < dirStack.length; i++) {
+          filteredEntries.push(dirStack[i]);
+        }
+        dirStack = [];
+        dirDepth = 0;
+
+        // Removing entries that are directories since exclude
+        // only excludes files when matched, if a file is not match,
+        // its directories should not be part of entries here, we are
+        // are assuming if we see two directories being added
+        // we should check the directory Depth and remove all directories
+        // with greater directory Depth
+        // eg. subdir1/
+        //     subdir1/subsubdir1/
+        //     subdir2 /
+        //
+        //    when the above happens, we should remove subdir1 & subsubdir1
+        const topFilteredEntry = filteredEntries[filteredEntries.length-1];
+        if (isDirectory(entry) && isDirectory(topEntry)) {
+          while (filteredEntries.length !== 0 && getDirDepth(topFilteredEntry.relativePath) >= getDirDepth(entry.relativePath)) {
+            filteredEntries.pop();
+            topFilteredEntry = filteredEntries[filteredEntries.length-1];
+          }
+        }
+        filteredEntries.push(entry);
+      } else if (isDirectory(entry)) {
+        // if filters didn't match, but entry is directory, keep the entry in
+        // a stack. We may need it if there is an entry that matched that
+        // requires us to mkdir the parent directories of the file
+        // eg. subdir1/subsubdir1/foo.png
+        //
+        // if the above matched, we must have mkdir for subdir1 and subsubdir1
+        const curDirDepth = getDirDepth(entry.relativePath);
+        while (dirStack.length !== 0 && dirDepth >= curDirDepth) {
+          dirStack.pop();
+          dirDepth--;
+        }
+        dirStack.push(entry);
+        dirDepth = curDirDepth;
+      }
+    });
+
+    const prevTree = new FSTree.fromEntries(this.prevEntries);
+    const newTree = FSTree.fromEntries(filteredEntries);
+    patches = prevTree.calculatePatch(newTree);
+    this.prevEntries = [];
+    filteredEntries.forEach(e => this.prevEntries.push(e));
+    return patches;
+  } else {
+    return this._changes.filter(change => {
+      return filterMatches(change[1], this.cwd, this.files, this.include, this.exclude);
+    }).map(change => {
+      return [change[0], change[1].replace(`${this.cwd}`, ''), change[2]];
+    });
+  }
 };
 
 FSTree.prototype.chdir = function(relativePath, options) {
@@ -646,8 +715,7 @@ FSTree.prototype.reread = function(newRoot) {
   }
 
   if (newRoot) {
-    validateRoot(newRoot);
-    this.root = path.normalize(newRoot + path.sep);
+    this.root = path.normalize(path.resolve(newRoot) + path.sep);
   }
 
   // TODO: stash current entries so we can calculate a diff
@@ -665,22 +733,11 @@ FSTree.prototype._ensureEntriesPopulated = function() {
 
 FSTree.prototype._track = function(operation, entry) {
   var relativePath = entryRelativePath(entry);
-  // ensure we dedupe changes (only take the last)
-  var position = this._relativePathToChange[relativePath];
-  if (position === undefined) {
-    // new, so append
-    this._relativePathToChange[relativePath] = this._changes.push([
-      operation,
-      relativePath,
-      entry
-    ]) - 1;
-  } else {
-    if (this._changes[position][0] !== operation) {
-      throw new Error('Two different operation is being done on the same file.');
-    }
-    // existing, so replace
-    this._changes[position][2] = entry;
-  }
+  this._relativePathToChange[relativePath] = this._changes.push([
+    operation,
+    relativePath,
+    entry
+  ]) - 1;
 };
 
 FSTree.prototype._insertAt = function(result, entry) {
@@ -748,7 +805,7 @@ function filterMatches(entryPath, cwd, files, include, exclude){
     return false;
   }
 
-  if ((files.length > 0) && (include.length > 0 || exclude.length > 0)) {
+  if ((files !== null && files.length > 0) && (include.length > 0 || exclude.length > 0)) {
     throw new Error('Cannot pass files option (array or function) and a include/exlude filter. You can only have one or the other');
   }
 
@@ -756,7 +813,7 @@ function filterMatches(entryPath, cwd, files, include, exclude){
     entryPath = entryPath.replace(`${cwd}/`, '');
   }
 
-  if (files.length > 0) {
+  if (files !== null) {
     // include only if it matches an entry in files
     return files.indexOf(entryPath) > -1;
   }

--- a/tests/fs-tree/fs-test.js
+++ b/tests/fs-tree/fs-test.js
@@ -1781,9 +1781,136 @@ describe('FSTree fs abstraction', function() {
       expect(changes).to.have.property('length', 0);
     });
 
-    //TODO add tests to test when srcTree = true
-    //TODO add tests for exclude when srcTree = true
-    //TODO add tests for files & include when srcTree = true
+    describe('srcTree is true', function() {
+      beforeEach(function() {
+        rimraf.sync(ROOT);
+        fs.mkdirpSync(ROOT);
+
+        fixturify.writeSync(ROOT, {
+          'hello.txt': "Hello, World!\n",
+          'goodbye.txt': 'Goodbye, World\n',
+          'a': {
+            'foo': {
+              'one.js': '',
+              'one.css': '',
+            },
+            'bar': {
+              'two.js': '',
+              'two.css': '',
+            }
+          },
+          'b': {
+            'four.txt': '',
+          },
+        });
+        debugger;
+        tree = new FSTree({
+          entries: walkSync.entries(ROOT),
+          root: ROOT,
+          srcTree: true,
+        });
+      });
+
+      afterEach(function() {
+        fs.removeSync(ROOT);
+      });
+
+      it('include filters with parent dir', function() {
+        tree.include = ['**/one.css'];
+        let changes = tree.changes();
+
+        expect(changes).to.have.property('length', 3);
+        expect(changes).to.have.deep.property('0.length', 3);
+        expect(changes).to.have.deep.property('0.0', 'mkdir');
+        expect(changes).to.have.deep.property('0.1', 'a');
+        expect(changes).to.have.deep.property('1.length', 3);
+        expect(changes).to.have.deep.property('1.0', 'mkdir');
+        expect(changes).to.have.deep.property('1.1', 'a/foo');
+        expect(changes).to.have.deep.property('2.length', 3);
+        expect(changes).to.have.deep.property('2.0', 'create');
+        expect(changes).to.have.deep.property('2.1', 'a/foo/one.css');
+      });
+
+      it('exclude filters with parent dir', function() {
+        tree.exclude = ['**/*.js', '**/two.css'];
+        let changes = tree.changes();
+
+        expect(changes).to.have.property('length', 7);
+        expect(changes).to.have.deep.property('0.length', 3);
+        expect(changes).to.have.deep.property('0.0', 'mkdir');
+        expect(changes).to.have.deep.property('0.1', 'a');
+        expect(changes).to.have.deep.property('1.length', 3);
+        expect(changes).to.have.deep.property('1.0', 'mkdir');
+        expect(changes).to.have.deep.property('1.1', 'a/foo');
+        expect(changes).to.have.deep.property('2.length', 3);
+        expect(changes).to.have.deep.property('2.0', 'create');
+        expect(changes).to.have.deep.property('2.1', 'a/foo/one.css');
+        expect(changes).to.have.deep.property('3.length', 3);
+        expect(changes).to.have.deep.property('3.0', 'mkdir');
+        expect(changes).to.have.deep.property('3.1', 'b');
+        expect(changes).to.have.deep.property('4.length', 3);
+        expect(changes).to.have.deep.property('4.0', 'create');
+        expect(changes).to.have.deep.property('4.1', 'b/four.txt');
+        expect(changes).to.have.deep.property('5.length', 3);
+        expect(changes).to.have.deep.property('5.0', 'create');
+        expect(changes).to.have.deep.property('5.1', 'goodbye.txt');
+        expect(changes).to.have.deep.property('6.length', 3);
+        expect(changes).to.have.deep.property('6.0', 'create');
+        expect(changes).to.have.deep.property('6.1', 'hello.txt');
+      });
+
+      it('include filters with parent dir', function() {
+        tree.include = ['**/one.css'];
+        let changes = tree.changes();
+
+        expect(changes).to.have.property('length', 3);
+        expect(changes).to.have.deep.property('0.length', 3);
+        expect(changes).to.have.deep.property('0.0', 'mkdir');
+        expect(changes).to.have.deep.property('0.1', 'a');
+        expect(changes).to.have.deep.property('1.length', 3);
+        expect(changes).to.have.deep.property('1.0', 'mkdir');
+        expect(changes).to.have.deep.property('1.1', 'a/foo');
+        expect(changes).to.have.deep.property('2.length', 3);
+        expect(changes).to.have.deep.property('2.0', 'create');
+        expect(changes).to.have.deep.property('2.1', 'a/foo/one.css');
+      });
+
+      it('include and exclude filters with parent dir', function() {
+        tree.include = ['**/*.js'];
+        tree.exclude = ['**/*.css', '**/*.txt'];
+        let changes = tree.changes();
+
+        expect(changes).to.have.property('length', 5);
+        expect(changes).to.have.deep.property('0.length', 3);
+        expect(changes).to.have.deep.property('0.0', 'mkdir');
+        expect(changes).to.have.deep.property('0.1', 'a');
+        expect(changes).to.have.deep.property('1.length', 3);
+        expect(changes).to.have.deep.property('1.0', 'mkdir');
+        expect(changes).to.have.deep.property('1.1', 'a/bar');
+        expect(changes).to.have.deep.property('2.length', 3);
+        expect(changes).to.have.deep.property('2.0', 'create');
+        expect(changes).to.have.deep.property('2.1', 'a/bar/two.js');
+        expect(changes).to.have.deep.property('3.length', 3);
+        expect(changes).to.have.deep.property('3.0', 'mkdir');
+        expect(changes).to.have.deep.property('3.1', 'a/foo');
+        expect(changes).to.have.deep.property('4.length', 3);
+        expect(changes).to.have.deep.property('4.0', 'create');
+        expect(changes).to.have.deep.property('4.1', 'a/foo/one.js');
+      });
+
+      it('file filters with parent dir', function() {
+        tree.files= ['b/four.txt'];
+        let changes = tree.changes();
+
+        expect(changes).to.have.property('length', 2);
+        expect(changes).to.have.deep.property('0.length', 3);
+        expect(changes).to.have.deep.property('0.0', 'mkdir');
+        expect(changes).to.have.deep.property('0.1', 'b');
+        expect(changes).to.have.deep.property('1.length', 3);
+        expect(changes).to.have.deep.property('1.0', 'create');
+        expect(changes).to.have.deep.property('1.1', 'b/four.txt');
+      });
+    });
 
     describe('order', function() {
 

--- a/tests/fs-tree/fs-test.js
+++ b/tests/fs-tree/fs-test.js
@@ -320,24 +320,6 @@ describe('FSTree fs abstraction', function() {
           '${ROOT}/my-directory/a' of a non-source tree.
         `);
       });
-
-      it('throws if given a relative path for a root', function() {
-        fixturify.writeSync(`${ROOT}/my-directory`, {
-          a: {
-            b: 'hello',
-          },
-          a2: 'guten tag'
-        });
-
-        let tree = new FSTree({
-          root: `${ROOT}/my-directory`,
-          srcTree: true,
-        });
-
-        expect(function() {
-          tree.reread('my-directory');
-        }).to.throw(`Root must be an absolute path, tree.root: 'my-directory'`);
-      });
     });
 
     describe('.findByRelativePath', function () {
@@ -1387,7 +1369,7 @@ describe('FSTree fs abstraction', function() {
       it('returns a new tree with filters set', function() {
         expect(tree.include).to.eql([]);
         expect(tree.exclude).to.eql([]);
-        expect(tree.files).to.eql([]);
+        expect(tree.files).to.eql(null);
         expect(tree.cwd).to.eql('');
 
         expect(tree.filtered({ include: ['*.js'] }).include).to.eql(['*.js']);
@@ -1798,6 +1780,10 @@ describe('FSTree fs abstraction', function() {
 
       expect(changes).to.have.property('length', 0);
     });
+
+    //TODO add tests to test when srcTree = true
+    //TODO add tests for exclude when srcTree = true
+    //TODO add tests for files & include when srcTree = true
 
     describe('order', function() {
 

--- a/tests/fs-tree/fs-test.js
+++ b/tests/fs-tree/fs-test.js
@@ -322,6 +322,33 @@ describe('FSTree fs abstraction', function() {
           'b',
         ]);
       });
+
+      it('throws if called with a new root for a non-source tree', function() {
+        fixturify.writeSync(`${ROOT}/my-directory`, {
+          a: {
+            b: 'hello',
+          },
+          a2: 'guten tag'
+        });
+
+        let tree = new FSTree({
+          root: `${ROOT}/my-directory`,
+          srcTree: false,
+        });
+
+        expect(tree.walkPaths()).to.eql([
+          'a/',
+          'a/b',
+          'a2'
+        ]);
+
+        expect(function() {
+          tree.reread(`${ROOT}/my-directory/a`);
+        }).to.throw(oneLine`
+          Cannot change root from '${ROOT}/my-directory/' to
+          '${ROOT}/my-directory/a' of a non-source tree.
+        `);
+      });
     });
 
     describe('.findByRelativePath', function () {

--- a/tests/fs-tree/fs-test.js
+++ b/tests/fs-tree/fs-test.js
@@ -1820,7 +1820,7 @@ describe('FSTree fs abstraction', function() {
             { relativePath: entry[0] === 'mkdir' ? entry[1] + '/' : entry[1],
               basePath,
               mode: entry[0] === 'mkdir' ? 16877 : 33188,
-              size: entry[2],
+              size: 0,
               mtime: 0,
               isDirectory: {},
             }];
@@ -1829,6 +1829,7 @@ describe('FSTree fs abstraction', function() {
 
       function makeComparable(changes){
         return changes.map(entry => {
+          entry[2].size = 0;
           entry[2].mtime = 0;
           entry[2].isDirectory = {};
           return entry;
@@ -1872,9 +1873,9 @@ describe('FSTree fs abstraction', function() {
         tree.include = ['**/one.css'];
         let changes = makeComparable(tree.changes());
         let expectedChanges = getExpectedChanges([
-          ['mkdir', 'a', 136],
-          ['mkdir', 'a/foo', 136],
-          ['create', 'a/foo/one.css', 0]], tree.root);
+          ['mkdir', 'a'],
+          ['mkdir', 'a/foo'],
+          ['create', 'a/foo/one.css']], tree.root);
 
         expect(changes).to.have.deep.equal(expectedChanges);
       });
@@ -1883,13 +1884,13 @@ describe('FSTree fs abstraction', function() {
         tree.exclude = ['**/*.js', '**/two.css'];
         let changes = makeComparable(tree.changes());
         let expectedChanges = getExpectedChanges([
-          ['mkdir', 'a', 136],
-          ['mkdir', 'a/foo', 136],
-          ['create', 'a/foo/one.css', 0],
-          ['mkdir', 'b', 102],
-          ['create', 'b/four.txt', 0],
-          ['create', 'goodbye.txt', 15],
-          ['create', 'hello.txt', 14]], tree.root);
+          ['mkdir', 'a'],
+          ['mkdir', 'a/foo'],
+          ['create', 'a/foo/one.css'],
+          ['mkdir', 'b'],
+          ['create', 'b/four.txt'],
+          ['create', 'goodbye.txt'],
+          ['create', 'hello.txt']], tree.root);
 
         expect(changes).to.have.deep.equal(expectedChanges);
       });
@@ -1899,11 +1900,11 @@ describe('FSTree fs abstraction', function() {
         tree.exclude = ['**/*.css', '**/*.txt'];
         let changes = makeComparable(tree.changes());
         let expectedChanges = getExpectedChanges([
-          ['mkdir', 'a', 136],
-          ['mkdir', 'a/bar', 136],
-          ['create', 'a/bar/two.js', 0],
-          ['mkdir', 'a/foo', 136],
-          ['create', 'a/foo/one.js', 0]], tree.root);
+          ['mkdir', 'a'],
+          ['mkdir', 'a/bar'],
+          ['create', 'a/bar/two.js'],
+          ['mkdir', 'a/foo'],
+          ['create', 'a/foo/one.js']], tree.root);
 
         expect(changes).to.have.deep.equal(expectedChanges);
       });
@@ -1912,8 +1913,8 @@ describe('FSTree fs abstraction', function() {
         tree.files= ['b/four.txt'];
         let changes = makeComparable(tree.changes());
         let expectedChanges = getExpectedChanges([
-          ['mkdir', 'b', 102],
-          ['create', 'b/four.txt', 0]], tree.root);
+          ['mkdir', 'b'],
+          ['create', 'b/four.txt']], tree.root);
 
         expect(changes).to.have.deep.equal(expectedChanges);
       });


### PR DESCRIPTION
Updating changes to do sort & expand operations when srcTree is true. This is needed for broccoli-funnel.

In the files & include case, we keep a stack of the directories we have visited but not matched. And once we got a match, the stack will get pushed into the output array. If no matches from those entries are found, we will pop from the stack.
In the exclude case, if we see a directory is getting pushed onto out output array when the top of the array if also a directory, we will pop if the two directory is at the same directory depth or if the directory entry to be pushed has a directory depth less than the top of the array. 
Examples of both can be found in comments in the code.