### PR TITLE
slice filteredEntries instead of entries for prevEntries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -469,7 +469,7 @@ FSTree.prototype.changes = function() {
     const prevTree = new FSTree.fromEntries(this.prevEntries);
     const newTree = FSTree.fromEntries(filteredEntries);
     patches = prevTree.calculatePatch(newTree);
-    this.prevEntries = this.entries.slice();
+    this.prevEntries = filteredEntries.slice();
     return patches;
   } else {
     return this._changes.filter(change => {


### PR DESCRIPTION
slice filteredEntries instead of entries for prevEntries