### PR TITLE
In chdir, cwd should be base case if if relativePath is '/'.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -481,7 +481,7 @@ FSTree.prototype.changes = function() {
 };
 
 FSTree.prototype.chdir = function(relativePath, options) {
-  let cwd = relativePath === '' ? '' : `${chompPathSep(relativePath)}/`;
+  let cwd = (relativePath === '' || relativePath === '/' ) ? '' : `${chompPathSep(relativePath)}/`;
 
   if (cwd === this.cwd) { return this; }
 

--- a/tests/fs-tree/fs-test.js
+++ b/tests/fs-tree/fs-test.js
@@ -1198,6 +1198,13 @@ describe('FSTree fs abstraction', function() {
         expect(result.cwd).to.equal('my-directory/');
       });
 
+      it('to / returns root', function() {
+        let result = tree.chdir('/');
+        expect(result).to.equal(tree);
+
+        expect(result.cwd).to.equal('');
+      });
+
       describe('when path does not exist', function() {
         it('throws without allowEmpty: true', function() {
           expect(function() {


### PR DESCRIPTION
In chdir, cwd should be base case if if relativePath is '/'.

The case I ran into was when _options passed to a plugin has `srcDir: '/'`
The plugin will call chDir passing in `relativePath = '/'`, setting `this.cwd = '/'`
Which causes `filterMatches` to return false when it evaluates `entryPath.indexOf(cwd) === -1` when entryPath is a file.
