### PR TITLE
fix: Actually publish the types file.

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,5 @@
+// Type definitions for "fs-tree-diff"
+// Definitions by: Adam Miller <https://github.com/amiller-gh>
 import fs from "fs";
 
 declare namespace FSTree {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.7",
   "description": "Backs out file tree changes",
   "main": "lib/index.js",
-  "types": "index.d.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],


### PR DESCRIPTION
The types file was in the default location for types, which meant it worked locally, but its not actually present in the published artifact! Moving it into `lib` will fix this.