### PR TITLE
Fix type declarations and docs for `defaultIsEqual`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ User specified `isEqual` will often want to use the default `isEqual`, so it is 
 Example
 
 ```js
-var defaultIsEqual = FSTtreeDiff.isEqual;
+var defaultIsEqual = FSTree.defaultIsEqual;
 
 function isEqualCheckingMeta(a, b) {
   return defaultIsEqual(a, b) && isMetaEqual(a, b);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -37,7 +37,7 @@ declare namespace FSTree {
 
 declare class FSTree {
   constructor(options?: PartialFSTreeOptions): FSTree;
-  calculatePatch(tree: FSTree, isEqual?: (a: FSTree, b: FSTree) => boolean): Patch[];
+  calculatePatch(tree: FSTree, isEqual?: (a: FSEntry, b: FSEntry) => boolean): Patch[];
   calculateAndApplyPatch(tree: FSTree, inputDir: string, outputDir: string, delegate?: FSTreeDelegates): void;
   addEntries(entries: Entry[], options?: PartialFSTreeOptions): void;
   addPaths(paths: string[], options?: PartialFSTreeOptions): void;
@@ -45,7 +45,7 @@ declare class FSTree {
   static fromPaths(paths: string[]): FSTree;
   static fromEntries(entries: Entry[]): FSTree;
   static applyPatch(inputDir: string, outputDir: string, patch: Patch[]): void;
-  static isEqual(a: FSTree, b: FSTree): boolean;
+  static defaultIsEqual(a: FSEntry, b: FSEntry): boolean;
 }
 
 export = FSTree;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -36,16 +36,16 @@ declare namespace FSTree {
 }
 
 declare class FSTree {
-  constructor(options?: PartialFSTreeOptions): FSTree;
-  calculatePatch(tree: FSTree, isEqual?: (a: FSEntry, b: FSEntry) => boolean): Patch[];
-  calculateAndApplyPatch(tree: FSTree, inputDir: string, outputDir: string, delegate?: FSTreeDelegates): void;
-  addEntries(entries: Entry[], options?: PartialFSTreeOptions): void;
-  addPaths(paths: string[], options?: PartialFSTreeOptions): void;
-  forEach(cb: (entry: FSEntry) => void, context?: any): void;
+  constructor(options?: FSTree.PartialFSTreeOptions);
+  calculatePatch(tree: FSTree, isEqual?: (a: FSTree.Entry, b: FSTree.Entry) => boolean): FSTree.Patch[];
+  calculateAndApplyPatch(tree: FSTree, inputDir: string, outputDir: string, delegate?: FSTree.FSTreeDelegates): void;
+  addEntries(entries: FSTree.Entry[], options?: FSTree.PartialFSTreeOptions): void;
+  addPaths(paths: string[], options?: FSTree.PartialFSTreeOptions): void;
+  forEach(cb: (entry: FSTree.Entry) => void, context?: any): void;
   static fromPaths(paths: string[]): FSTree;
-  static fromEntries(entries: Entry[]): FSTree;
-  static applyPatch(inputDir: string, outputDir: string, patch: Patch[]): void;
-  static defaultIsEqual(a: FSEntry, b: FSEntry): boolean;
+  static fromEntries(entries: FSTree.Entry[]): FSTree;
+  static applyPatch(inputDir: string, outputDir: string, patch: FSTree.Patch[]): void;
+  static defaultIsEqual(a: FSTree.Entry, b: FSTree.Entry): boolean;
 }
 
 export = FSTree;


### PR DESCRIPTION
Both the type declarations and the README indicate that the default equality function is at `FSTree.isEqual`, but the actual implementation places it at `FSTree.defaultIsEqual`. The type declarations also have `isEqual` receiving `FSTree` instances rather than `FSEntry` ones. 

This updates both the types and the README to reflect reality.

Edit: actually, the type declarations were more broadly broken than that; none of the types from the `FSTree` namespace were resolving correctly within the `FSTree` class declaration itself. This now also includes a fix for that.