### PR TITLE
Fix export + types test

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -48,4 +48,4 @@ declare class FSTree {
   static defaultIsEqual(a: FSTree.Entry, b: FSTree.Entry): boolean;
 }
 
-export default FSTree;
+export = FSTree;

--- a/tests.ts/index.ts
+++ b/tests.ts/index.ts
@@ -1,3 +1,3 @@
 // validate that these type annotations at least type check
-import FSTree from '../lib/index';
+import * as FSTree from '../lib/index';
 


### PR DESCRIPTION
types test actually changed the export from a module export to a default export, which is wrong.

fixed the test (and `index.d.ts`) to reflect intended usage